### PR TITLE
Parse colors into integers and set onboard LED

### DIFF
--- a/src/led-from-azure.ino
+++ b/src/led-from-azure.ino
@@ -1,0 +1,25 @@
+void setup() {
+    RGB.control(true);
+    RGB.brightness(0);
+    
+    Particle.function("setLed", setLed);
+}
+
+void loop() {
+
+}
+
+int setLed(String colors) {
+    Particle.publish("received-request", colors, 60, PRIVATE);
+    
+    RGB.brightness(255);
+    
+    String red = colors.substring(0, 3);
+    String green = colors.substring(4, 7);
+    String blue = colors.substring(8, 11);
+    RGB.color(red.toInt(), green.toInt(), blue.toInt());
+    delay(1000);
+
+    RGB.brightness(0);
+    return 0;
+}


### PR DESCRIPTION
To be called from an Azure function, this sketch exposes a Particle function that takes a string in the form "255,255,255" (fixed-size, zero-filled) and parses it into three integers to set the color for the on-board LED.